### PR TITLE
Authn should be ready for production

### DIFF
--- a/authn/webapi/sessions/infraclientx/README.md
+++ b/authn/webapi/sessions/infraclientx/README.md
@@ -1,0 +1,5 @@
+### InfraClientX
+
+An collection of modules to fetch and verify sessions for microservices.
+
+This moves downstream to the Weblog toolbox as [InfraClientX](https://github.com/taylor-vann/weblog/toolbox/golang/infraclientx).


### PR DESCRIPTION
StoreInit should create users and roles for Development and Production.

When Authn runs in Production:

Sessions will provide access to tokens in DEVELOPMENT and tokens in PRODUCTION.
Users and Roles will also have two tables for prod and development.

Our JSON requests to the Authn API will default to DEVELOPMENT unless explicitly called for production.

This way we can setup a pattern that lets us test features in prod before "flipping the switch".
